### PR TITLE
Add "Seven Go Low" game option support

### DIFF
--- a/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
+++ b/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
@@ -27,7 +27,7 @@ import net.yura.shithead.uicomponents.Icons;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.jar.Manifest;
@@ -95,11 +95,8 @@ public class MiniLobbyShithead implements MiniLobbyGame {
             int timeout = Integer.parseInt(((Option) ((ComboBox) loader.find("TimeoutValue")).getSelectedItem()).getKey());
 
             Hashtable formData = loader.getFormData();
-            Map<String, String> optionsMap = new HashMap<>();
-            if ("true".equals(formData.get("sevenGoLow"))) {
-                optionsMap.put("sevenGoLow", "true");
-            }
-            Game newGame = new Game(gameName, SerializerUtil.optionsToJson(optionsMap), numPlayers, timeout);
+            formData.keySet().retainAll(Collections.singletonList("sevenGoLow"));
+            Game newGame = new Game(gameName, SerializerUtil.optionsToJson(formData), numPlayers, timeout);
 
             if (((Button) loader.find("private")).isSelected()) {
                 newGame.setMagicWord(((TextComponent) loader.find("password")).getText());

--- a/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
+++ b/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
@@ -27,6 +27,8 @@ import net.yura.shithead.uicomponents.Icons;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.jar.Manifest;
 
 public class MiniLobbyShithead implements MiniLobbyGame {
@@ -74,6 +76,10 @@ public class MiniLobbyShithead implements MiniLobbyGame {
 
     @Override
     public String getGameDescription(Game game) {
+        Map<String, String> options = SerializerUtil.optionsFromJson(game.getOptions());
+        if ("true".equals(options.get("sevenGoLow"))) {
+            return strings.getProperty("newgame.sevengolow");
+        }
         return "";
     }
 
@@ -87,8 +93,11 @@ public class MiniLobbyShithead implements MiniLobbyGame {
             String gameName = gamename.getText();
             int timeout = Integer.parseInt(((Option) ((ComboBox) loader.find("TimeoutValue")).getSelectedItem()).getKey());
 
-            // TODO for now options cant be null, but in next version of lobby it can
-            Game newGame = new Game(gameName, "blank", numPlayers, timeout);
+            Map<String, String> optionsMap = new HashMap<>();
+            if (((Button) loader.find("sevenGoLow")).isSelected()) {
+                optionsMap.put("sevenGoLow", "true");
+            }
+            Game newGame = new Game(gameName, SerializerUtil.optionsToJson(optionsMap), numPlayers, timeout);
 
             if (((Button) loader.find("private")).isSelected()) {
                 newGame.setMagicWord(((TextComponent) loader.find("password")).getText());

--- a/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
+++ b/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.jar.Manifest;
 
@@ -93,8 +94,9 @@ public class MiniLobbyShithead implements MiniLobbyGame {
             String gameName = gamename.getText();
             int timeout = Integer.parseInt(((Option) ((ComboBox) loader.find("TimeoutValue")).getSelectedItem()).getKey());
 
+            Hashtable formData = loader.getFormData();
             Map<String, String> optionsMap = new HashMap<>();
-            if (((Button) loader.find("sevenGoLow")).isSelected()) {
+            if ("true".equals(formData.get("sevenGoLow"))) {
                 optionsMap.put("sevenGoLow", "true");
             }
             Game newGame = new Game(gameName, SerializerUtil.optionsToJson(optionsMap), numPlayers, timeout);

--- a/client/src/main/resources/game_setup.xml
+++ b/client/src/main/resources/game_setup.xml
@@ -23,6 +23,9 @@
         <choice i18n="true" name="86400" text="newgame.timeout.24hours"/>
     </combobox>
 
+    <checkbox i18n="true" name="sevenGoLow" text="newgame.sevengolow"/>
+    <label text=""/>
+
     <checkbox action="private" i18n="true" name="private" text="newgame.private"/>
     <textfield name="password" enabled="false" property="hint=newgame.password"/>
 

--- a/client/src/main/resources/game_setup.xml
+++ b/client/src/main/resources/game_setup.xml
@@ -23,8 +23,7 @@
         <choice i18n="true" name="86400" text="newgame.timeout.24hours"/>
     </combobox>
 
-    <checkbox i18n="true" name="sevenGoLow" text="newgame.sevengolow"/>
-    <label text=""/>
+    <checkbox colspan="2" i18n="true" name="sevenGoLow" text="newgame.sevengolow"/>
 
     <checkbox action="private" i18n="true" name="private" text="newgame.private"/>
     <textfield name="password" enabled="false" property="hint=newgame.password"/>

--- a/client/src/main/resources/game_text.properties
+++ b/client/src/main/resources/game_text.properties
@@ -25,6 +25,7 @@ newgame.timeout.30sec=30sec
 newgame.timeout.5min=5min
 newgame.timeout.6hours=6hours
 
+newgame.sevengolow=7 Go Low
 newgame.private=Private
 newgame.password=Password
 

--- a/server/src/main/java/net/yura/shithead/server/ShitHeadServer.java
+++ b/server/src/main/java/net/yura/shithead/server/ShitHeadServer.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -31,6 +32,8 @@ public class ShitHeadServer extends AbstractTurnBasedServerGame {
     public void startGame(String[] players) {
         // TODO may need to shuffle the players
         game = new ShitheadGame(Arrays.asList(players));
+        Map<String, String> options = SerializerUtil.optionsFromJson(startGameOptions);
+        game.setSevenGoLow("true".equals(options.get("sevenGoLow")));
         game.deal();
         // we are in re-arrange mode, anyone can go
 

--- a/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
+++ b/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
@@ -114,7 +114,7 @@ public class SerializerUtil {
             return mapper.readValue(json, new TypeReference<Map<String, String>>(){});
         }
         catch (JsonProcessingException e) {
-            return new HashMap<>();
+            throw new IllegalArgumentException("bad options json " + json, e);
         }
     }
 }

--- a/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
+++ b/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
@@ -1,6 +1,7 @@
 package net.yura.shithead.common.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
@@ -93,6 +94,27 @@ public class SerializerUtil {
         }
         catch (JsonProcessingException e) {
             throw new IllegalArgumentException("bad json " + json, e);
+        }
+    }
+
+    public static String optionsToJson(Map<String, String> options) {
+        try {
+            return mapper.writeValueAsString(options);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static Map<String, String> optionsFromJson(String json) {
+        if (json == null) {
+            return new HashMap<>();
+        }
+        try {
+            return mapper.readValue(json, new TypeReference<Map<String, String>>(){});
+        }
+        catch (JsonProcessingException e) {
+            return new HashMap<>();
         }
     }
 }

--- a/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
+++ b/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
@@ -97,7 +97,7 @@ public class SerializerUtil {
         }
     }
 
-    public static String optionsToJson(Map<String, String> options) {
+    public static String optionsToJson(Map<?,?> options) {
         try {
             return mapper.writeValueAsString(options);
         }

--- a/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
+++ b/src/main/java/net/yura/shithead/common/json/SerializerUtil.java
@@ -107,7 +107,7 @@ public class SerializerUtil {
     }
 
     public static Map<String, String> optionsFromJson(String json) {
-        if (json == null) {
+        if (json == null || json.isEmpty()) {
             return new HashMap<>();
         }
         try {


### PR DESCRIPTION
## Summary
This PR adds support for a "Seven Go Low" game option that players can enable when creating a new game. The option is serialized with the game configuration and applied on the server when the game starts.

## Key Changes
- **SerializerUtil**: Added `optionsToJson()` and `optionsFromJson()` utility methods to serialize/deserialize game options as JSON-formatted strings using Jackson's `TypeReference`
- **Game Setup UI**: Added a checkbox for the "Seven Go Low" option in the game setup dialog (`game_setup.xml`)
- **MiniLobbyShithead**: 
  - Updated `getGameDescription()` to display the "Seven Go Low" label when the option is enabled
  - Modified `openGameSetup()` to capture the checkbox state and pass it to the Game constructor via serialized options
- **ShitHeadServer**: Updated `startGame()` to deserialize game options and apply the "Seven Go Low" setting to the game instance via `setSevenGoLow()`
- **Localization**: Added `newgame.sevengolow=7 Go Low` property to `game_text.properties`

## Implementation Details
- Game options are stored as a JSON string in the Game object, allowing for flexible extensibility
- The server deserializes options on game start and applies them to the `ShitheadGame` instance
- Null/missing options gracefully default to an empty map, maintaining backward compatibility

https://claude.ai/code/session_01JAQCWXRoEUeRGQMhArbLgo