### PR TITLE
Add seven-go-low rule option to singleplayer game setup

### DIFF
--- a/client/src/main/java/net/yura/shithead/client/ShitHeadApplication.java
+++ b/client/src/main/java/net/yura/shithead/client/ShitHeadApplication.java
@@ -141,7 +141,8 @@ public class ShitHeadApplication extends Application implements ActionListener {
             XULLoader gameSetupLoader = createNewGameScreen(properties, loader -> {
                 Spinner players = (Spinner)loader.find("players");
                 int numPlayers = (Integer)players.getValue();
-                createNewSinglePlayerGame(numPlayers);
+                boolean sevenGoLow = ((Button)loader.find("sevenGoLow")).isSelected();
+                createNewSinglePlayerGame(numPlayers, sevenGoLow);
             });
 
             gameSetupLoader.find("gamenameLabel").setVisible(false);
@@ -220,9 +221,10 @@ public class ShitHeadApplication extends Application implements ActionListener {
         frame.repaint();
     }
 
-    private void createNewSinglePlayerGame(int numPlayers) {
+    private void createNewSinglePlayerGame(int numPlayers, boolean sevenGoLow) {
 
         ShitheadGame singlePlayerGame = new ShitheadGame(numPlayers);
+        singlePlayerGame.setSevenGoLow(sevenGoLow);
         singlePlayerGame.deal();
 
         // TODO maybe we want to use AutoPlay for this also?


### PR DESCRIPTION
## Summary
Added support for the "seven go low" rule as a configurable option in the singleplayer game setup screen.

## Key Changes
- Modified the singleplayer game setup UI to include a "sevenGoLow" button/checkbox that players can toggle
- Updated `createNewSinglePlayerGame()` method to accept a `sevenGoLow` boolean parameter
- Pass the selected rule option to the `ShitheadGame` instance via the new `setSevenGoLow()` method before dealing cards

## Implementation Details
- The "sevenGoLow" button state is read from the game setup loader during game initialization
- The rule preference is applied to the game object immediately after instantiation and before the deal phase

https://claude.ai/code/session_01TTsPsxovxYVqU9HcbsL6gP