### PR TITLE
Add support for configurable number of decks in Shithead games

### DIFF
--- a/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
+++ b/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
@@ -26,6 +26,7 @@ import net.yura.shithead.uicomponents.CardImageManager;
 import net.yura.shithead.uicomponents.Icons;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
@@ -95,7 +96,9 @@ public class MiniLobbyShithead implements MiniLobbyGame {
             int timeout = Integer.parseInt(((Option) ((ComboBox) loader.find("TimeoutValue")).getSelectedItem()).getKey());
 
             Hashtable formData = loader.getFormData();
-            formData.keySet().retainAll(Collections.singletonList("sevenGoLow"));
+            formData.keySet().retainAll(Arrays.asList("sevenGoLow", "numDecks"));
+            Spinner numDecksSpinner = (Spinner)loader.find("numDecks");
+            formData.put("numDecks", String.valueOf(numDecksSpinner.getValue()));
             Game newGame = new Game(gameName, SerializerUtil.optionsToJson(formData), numPlayers, timeout);
 
             if (((Button) loader.find("private")).isSelected()) {

--- a/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
+++ b/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
@@ -26,7 +26,6 @@ import net.yura.shithead.uicomponents.CardImageManager;
 import net.yura.shithead.uicomponents.Icons;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Hashtable;
@@ -96,9 +95,8 @@ public class MiniLobbyShithead implements MiniLobbyGame {
             int timeout = Integer.parseInt(((Option) ((ComboBox) loader.find("TimeoutValue")).getSelectedItem()).getKey());
 
             Hashtable formData = loader.getFormData();
-            formData.keySet().retainAll(Arrays.asList("sevenGoLow", "numDecks"));
-            Spinner numDecksSpinner = (Spinner)loader.find("numDecks");
-            formData.put("numDecks", String.valueOf(numDecksSpinner.getValue()));
+            formData.keySet().retainAll(Collections.singletonList("sevenGoLow"));
+            formData.put("numDecks", String.valueOf(((Spinner)loader.find("numDecks")).getValue()));
             Game newGame = new Game(gameName, SerializerUtil.optionsToJson(formData), numPlayers, timeout);
 
             if (((Button) loader.find("private")).isSelected()) {

--- a/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
+++ b/client/src/main/java/net/yura/shithead/client/MiniLobbyShithead.java
@@ -96,7 +96,8 @@ public class MiniLobbyShithead implements MiniLobbyGame {
 
             Hashtable formData = loader.getFormData();
             formData.keySet().retainAll(Collections.singletonList("sevenGoLow"));
-            formData.put("numDecks", String.valueOf(((Spinner)loader.find("numDecks")).getValue()));
+            // TODO form data not collecting spinner data, remove when switched to new SwingME version
+            formData.put("numDecks", String.valueOf((loader.find("numDecks")).getValue()));
             Game newGame = new Game(gameName, SerializerUtil.optionsToJson(formData), numPlayers, timeout);
 
             if (((Button) loader.find("private")).isSelected()) {

--- a/client/src/main/java/net/yura/shithead/client/ShitHeadApplication.java
+++ b/client/src/main/java/net/yura/shithead/client/ShitHeadApplication.java
@@ -141,8 +141,9 @@ public class ShitHeadApplication extends Application implements ActionListener {
             XULLoader gameSetupLoader = createNewGameScreen(properties, loader -> {
                 Spinner players = (Spinner)loader.find("players");
                 int numPlayers = (Integer)players.getValue();
+                int numDecks = (Integer)((Spinner)loader.find("numDecks")).getValue();
                 boolean sevenGoLow = ((Button)loader.find("sevenGoLow")).isSelected();
-                createNewSinglePlayerGame(numPlayers, sevenGoLow);
+                createNewSinglePlayerGame(numPlayers, numDecks, sevenGoLow);
             });
 
             gameSetupLoader.find("gamenameLabel").setVisible(false);
@@ -221,9 +222,9 @@ public class ShitHeadApplication extends Application implements ActionListener {
         frame.repaint();
     }
 
-    private void createNewSinglePlayerGame(int numPlayers, boolean sevenGoLow) {
+    private void createNewSinglePlayerGame(int numPlayers, int numDecks, boolean sevenGoLow) {
 
-        ShitheadGame singlePlayerGame = new ShitheadGame(numPlayers);
+        ShitheadGame singlePlayerGame = new ShitheadGame(numPlayers, numDecks);
         singlePlayerGame.setSevenGoLow(sevenGoLow);
         singlePlayerGame.deal();
 

--- a/client/src/main/resources/game_setup.xml
+++ b/client/src/main/resources/game_setup.xml
@@ -6,6 +6,9 @@
     <label i18n="true" text="newgame.players.number"/>
     <spinbox maximum="5" minimum="2" name="players" text="2"/>
 
+    <label i18n="true" text="newgame.decks.number"/>
+    <spinbox maximum="4" minimum="1" name="numDecks" text="1"/>
+
     <label alignment="right" i18n="true" text="newgame.label.timeout" weightx="1" name="timeoutLabel"/>
     <combobox editable="false" name="TimeoutValue" selected="3" text="newgame.timeout.1min">
         <choice i18n="true" name="10" text="newgame.timeout.10sec"/>

--- a/client/src/main/resources/game_text.properties
+++ b/client/src/main/resources/game_text.properties
@@ -7,6 +7,7 @@ about.title = \ud83c\udcad About ShitHead
 newgame.title=Create Game
 newgame.name=Game Name:
 newgame.players.number=No Players:
+newgame.decks.number=No Decks:
 newgame.button.back=Cancel
 newgame.button.create=Create
 

--- a/server/src/main/java/net/yura/shithead/server/ShitHeadServer.java
+++ b/server/src/main/java/net/yura/shithead/server/ShitHeadServer.java
@@ -31,8 +31,9 @@ public class ShitHeadServer extends AbstractTurnBasedServerGame {
     @Override
     public void startGame(String[] players) {
         // TODO may need to shuffle the players
-        game = new ShitheadGame(Arrays.asList(players));
         Map<String, String> options = SerializerUtil.optionsFromJson(startGameOptions);
+        int numDecks = options.containsKey("numDecks") ? Integer.parseInt(options.get("numDecks")) : 1;
+        game = new ShitheadGame(Arrays.asList(players), numDecks);
         game.setSevenGoLow("true".equals(options.get("sevenGoLow")));
         game.deal();
         // we are in re-arrange mode, anyone can go

--- a/src/main/java/net/yura/shithead/common/ShitheadGame.java
+++ b/src/main/java/net/yura/shithead/common/ShitheadGame.java
@@ -46,7 +46,11 @@ public class ShitheadGame {
      * @param playerCount number of players taking part
      */
     public ShitheadGame(int playerCount) {
-        this(playerCount, new Deck(1));
+        this(playerCount, 1);
+    }
+
+    public ShitheadGame(int playerCount, int numDecks) {
+        this(playerCount, new Deck(numDecks));
     }
 
     /**
@@ -68,7 +72,11 @@ public class ShitheadGame {
      * @param playerNames list of player names
      */
     public ShitheadGame(List<String> playerNames) {
-        this(playerNames, new Deck(1));
+        this(playerNames, 1);
+    }
+
+    public ShitheadGame(List<String> playerNames, int numDecks) {
+        this(playerNames, new Deck(numDecks));
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR adds the ability to configure the number of decks used in Shithead games, allowing players to customize gameplay with 1-4 decks instead of being limited to a single deck.

## Key Changes
- **Core Game Logic**: Added new overloaded constructors to `ShitheadGame` that accept a `numDecks` parameter, allowing flexible deck configuration while maintaining backward compatibility
- **Single Player Mode**: Updated the single-player game creation flow to accept and pass through the number of decks from the UI
- **Multiplayer/Server Mode**: Modified `ShitHeadServer` to read the `numDecks` option from game configuration and apply it when creating games
- **UI Components**: 
  - Added a new spinner control in `game_setup.xml` to allow users to select 1-4 decks
  - Updated both single-player and multiplayer game setup screens to capture the deck count
  - Added corresponding i18n text entry for the new UI label
- **Configuration Handling**: Enhanced `MiniLobbyShithead` to properly serialize and pass the `numDecks` option through the game creation pipeline

## Implementation Details
- The changes maintain backward compatibility by defaulting to 1 deck when the parameter is not specified
- The deck count is configurable through both the single-player UI and multiplayer game options
- Server-side game creation now respects the `numDecks` option from the game configuration JSON

https://claude.ai/code/session_01YMgEYCtDGCRKxZMWJBBkzW