### PR TITLE
Update GitHub Actions for Node.js 24 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,22 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@v4
 
     - name: Run tests with Gradle
       run: ./gradlew test
 
     - name: Test Report
-      uses: dorny/test-reporter@v2
+      uses: dorny/test-reporter@v3
       if: ${{ always() }}
       with:
         name: JUnit Tests
@@ -40,7 +40,7 @@ jobs:
 
     - name: Upload image on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: failure-image
         path: desktop/testOutput/


### PR DESCRIPTION
Updated GitHub Actions in `.github/workflows/ci.yml` to resolve Node.js 20 deprecation warnings. The following actions were updated to their latest major versions which support Node.js 24: `actions/checkout@v7`, `actions/setup-java@v5`, `android-actions/setup-android@v4`, `dorny/test-reporter@v3`, and `actions/upload-artifact@v7`.

---
*PR created automatically by Jules for task [18223302292544910663](https://jules.google.com/task/18223302292544910663) started by @sdyura*