### PR TITLE
Show full stack traces for test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,16 @@ jobs:
     - name: Run tests with Gradle
       run: ./gradlew test
 
+
+#    - name: Test Report
+#      uses: dorny/test-reporter@v3
+#      if: ${{ always() }}
+#      with:
+#        name: JUnit Tests
+#        path: "**/build/test-results/test/TEST-*.xml"
+#        reporter: java-junit
+
+# use another test report instead as this one shows full stack traces
     - name: Test Report
       uses: mikepenz/action-junit-report@v6
       if: ${{ always() }}
@@ -37,9 +47,7 @@ jobs:
         check_name: JUnit Tests
         report_paths: "**/build/test-results/test/TEST-*.xml"
         detailed_summary: true
-        include_skipped: false
-        skip_success_summary: true
-        truncate_stack_traces: false
+        include_passed: true
 
     - name: Upload image on failure
       if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,51 +37,10 @@ jobs:
         name: JUnit Tests
         path: "**/build/test-results/test/TEST-*.xml"
         reporter: java-junit
-
-    - name: Full test failure details
-      if: ${{ always() }}
-      shell: python
-      run: |
-        import glob
-        import html
-        import os
-        import xml.etree.ElementTree as ET
-
-        report_paths = sorted(glob.glob('**/build/test-results/test/TEST-*.xml', recursive=True))
-        failures = []
-
-        for report_path in report_paths:
-            try:
-                root = ET.parse(report_path).getroot()
-            except ET.ParseError as exc:
-                failures.append((report_path, 'Unable to parse test report', f'{type(exc).__name__}: {exc}'))
-                continue
-
-            for testcase in root.iter('testcase'):
-                test_name = testcase.attrib.get('name', '<unknown test>')
-                class_name = testcase.attrib.get('classname', '')
-                display_name = f'{class_name}.{test_name}' if class_name else test_name
-
-                for result in list(testcase):
-                    if result.tag not in ('failure', 'error'):
-                        continue
-
-                    message = result.attrib.get('message', '').strip()
-                    stack_trace = (result.text or '').strip()
-                    details = stack_trace or message or '<no failure details recorded>'
-                    if message and message not in details:
-                        details = f'{message}\n{details}'
-                    failures.append((report_path, display_name, details))
-
-        if failures:
-            with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as summary:
-                summary.write('## Full test failure details\n\n')
-                for report_path, display_name, details in failures:
-                    summary.write(f'### ❌ {html.escape(display_name)}\n\n')
-                    summary.write(f'JUnit report: `{report_path}`\n\n')
-                    summary.write('```text\n')
-                    summary.write(details.replace('```', "'''"))
-                    summary.write('\n```\n\n')
+        list-suites: failed
+        list-tests: failed
+        max-annotations: '50'
+        collapsed: never
 
     - name: Upload image on failure
       if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,15 @@ jobs:
       run: ./gradlew test
 
     - name: Test Report
-      uses: dorny/test-reporter@v3
+      uses: mikepenz/action-junit-report@v6
       if: ${{ always() }}
       with:
-        name: JUnit Tests
-        path: "**/build/test-results/test/TEST-*.xml"
-        reporter: java-junit
-        list-suites: failed
-        list-tests: failed
-        max-annotations: '50'
-        collapsed: never
+        check_name: JUnit Tests
+        report_paths: "**/build/test-results/test/TEST-*.xml"
+        detailed_summary: true
+        include_skipped: false
+        skip_success_summary: true
+        truncate_stack_traces: false
 
     - name: Upload image on failure
       if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,57 @@ jobs:
       run: ./gradlew test
 
     - name: Test Report
-      uses: dorny/test-reporter@v2
+      uses: dorny/test-reporter@v3
       if: ${{ always() }}
       with:
         name: JUnit Tests
         path: "**/build/test-results/test/TEST-*.xml"
         reporter: java-junit
+
+    - name: Full test failure details
+      if: ${{ always() }}
+      shell: python
+      run: |
+        import glob
+        import html
+        import os
+        import xml.etree.ElementTree as ET
+
+        report_paths = sorted(glob.glob('**/build/test-results/test/TEST-*.xml', recursive=True))
+        failures = []
+
+        for report_path in report_paths:
+            try:
+                root = ET.parse(report_path).getroot()
+            except ET.ParseError as exc:
+                failures.append((report_path, 'Unable to parse test report', f'{type(exc).__name__}: {exc}'))
+                continue
+
+            for testcase in root.iter('testcase'):
+                test_name = testcase.attrib.get('name', '<unknown test>')
+                class_name = testcase.attrib.get('classname', '')
+                display_name = f'{class_name}.{test_name}' if class_name else test_name
+
+                for result in list(testcase):
+                    if result.tag not in ('failure', 'error'):
+                        continue
+
+                    message = result.attrib.get('message', '').strip()
+                    stack_trace = (result.text or '').strip()
+                    details = stack_trace or message or '<no failure details recorded>'
+                    if message and message not in details:
+                        details = f'{message}\n{details}'
+                    failures.append((report_path, display_name, details))
+
+        if failures:
+            with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as summary:
+                summary.write('## Full test failure details\n\n')
+                for report_path, display_name, details in failures:
+                    summary.write(f'### ❌ {html.escape(display_name)}\n\n')
+                    summary.write(f'JUnit report: `{report_path}`\n\n')
+                    summary.write('```text\n')
+                    summary.write(details.replace('```', "'''"))
+                    summary.write('\n```\n\n')
 
     - name: Upload image on failure
       if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,6 @@ allprojects {
 
     tasks.withType(Test) {
         useJUnitPlatform()
-        testLogging {
-            events 'failed'
-            exceptionFormat 'full'
-        }
         reports {
             junitXml.required.set(true)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ allprojects {
 
     tasks.withType(Test) {
         useJUnitPlatform()
+        testLogging {
+            events 'failed'
+            exceptionFormat 'full'
+        }
         reports {
             junitXml.required.set(true)
         }


### PR DESCRIPTION
### Motivation
- Test runners currently only show a single-line failure summary and should display full exception stack traces to make debugging failing tests easier.

### Description
- Enable Gradle `testLogging` in the top-level `build.gradle` under `tasks.withType(Test)` and set `events 'failed'` with `exceptionFormat 'full'` so failed test output includes full stack traces.

### Testing
- Ran `./gradlew :help --no-daemon`, which completed successfully. 
- Ran `./gradlew :test --no-daemon`, which was blocked by dependency resolution errors (HTTP 403 fetching JUnit/Mockito artifacts) so test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37de7d9b5c8331b5fea03bd5d7e90a)