### PR TITLE
Codex: Fix multi-deck UICard reuse and add 2-/3-deck layout tests

### DIFF
--- a/client/src/main/java/net/yura/shithead/uicomponents/GameView.java
+++ b/client/src/main/java/net/yura/shithead/uicomponents/GameView.java
@@ -29,7 +29,6 @@ public class GameView extends Panel {
     private String myUsername;
     private String title;
     private final List<UICard> deckAndWasteUICards = new ArrayList<UICard>();
-    private final Map<Card, UICard> cardToUICard = new HashMap<>();
     private final Map<Player, PlayerHand> playerHands = new HashMap<Player, PlayerHand>();
 
     private final int padding = XULLoader.adjustSizeToDensity(2);
@@ -352,35 +351,30 @@ public class GameView extends Panel {
     }
 
     private UICard getUICard(List<UICard> available, List<UICard> currentHandCardsAtLocation, Card card, CardLocation location, boolean isFaceUp) {
-        UICard uiCard = cardToUICard.get(card);
-        if (uiCard == null) {
-            // if this card is unknown, maybe we can find an existing unknown card at this location, then just use that card
-            if (card == null) {
-                Optional<UICard> currentCard = currentHandCardsAtLocation.stream().filter(uic -> uic.getCard() == null).findFirst();
-                if (currentCard.isPresent()) {
-                    currentHandCardsAtLocation.remove(currentCard.get());
-                    uiCard = currentCard.get();
-                }
-            }
+        UICard uiCard = null;
+        // Card instances are singletons, so the same Card object can appear more than once when a game uses multiple decks.
+        // Reuse only a UICard that belongs to this exact location/current pool instead of globally mapping one Card to one UICard.
+        Optional<UICard> currentCard = currentHandCardsAtLocation.stream().filter(uic -> uic.getCard() == card).findFirst();
+        if (currentCard.isPresent()) {
+            currentHandCardsAtLocation.remove(currentCard.get());
+            uiCard = currentCard.get();
+        }
 
+        if (uiCard == null && !available.isEmpty()) {
+            uiCard = available.stream().filter(c -> c.getCard() == card).findFirst().orElseGet(
+                    () -> available.stream().filter(c -> c.getCard() == null).findFirst().orElse(null)
+            );
+            if (uiCard != null) {
+                available.remove(uiCard);
+            }
+        }
+        if (uiCard == null) {
+            uiCard = StreamSupport.stream(((Iterable<UICard>) () -> new ReverseListIterator<>(deckAndWasteUICards)).spliterator(), false)
+                    .filter(c -> c.getLocation() == CardLocation.DECK).findFirst().orElse(null);
             if (uiCard == null) {
-                if (!available.isEmpty()) {
-                    uiCard = available.stream().filter(c -> c.getCard() == card).findFirst().orElseGet(
-                            () -> available.stream().filter(c -> c.getCard() == null).findFirst().orElse(null)
-                    );
-                    if (uiCard != null) {
-                        available.remove(uiCard);
-                    }
-                }
-                if (uiCard == null) {
-                    uiCard = StreamSupport.stream(((Iterable<UICard>) () -> new ReverseListIterator<>(deckAndWasteUICards)).spliterator(), false)
-                            .filter(c -> c.getLocation() == CardLocation.DECK).findFirst().orElse(null);
-                    if (uiCard == null) {
-                        // dealing a brand new card, this should ONLY happen at the start of the game
-                        System.out.println("Dealing new card on table (ONLY AT START OF GAME)");
-                        uiCard = new UICard();
-                    }
-                }
+                // dealing a brand new card, this should ONLY happen at the start of the game
+                System.out.println("Dealing new card on table (ONLY AT START OF GAME)");
+                uiCard = new UICard();
             }
         }
         updateCardInfo(uiCard, card, location, isFaceUp);
@@ -402,9 +396,6 @@ public class GameView extends Panel {
         uiCard.setPlayable(false);
         uiCard.setLocation(location);
         uiCard.setFaceUp(isFaceUp);
-        if (card != null) {
-            cardToUICard.put(card, uiCard);
-        }
     }
 
     @Override

--- a/desktop/src/test/java/net/yura/shithead/uicomponents/GameViewTest.java
+++ b/desktop/src/test/java/net/yura/shithead/uicomponents/GameViewTest.java
@@ -105,6 +105,18 @@ class GameViewTest {
         assertLayout(game);
     }
 
+    @Test
+    void testInitialCardPositionsAfterAnimationWithTwoDecks() throws Exception {
+        ShitheadGame game = newGame(2);
+        assertLayout(game);
+    }
+
+    @Test
+    void testInitialCardPositionsAfterAnimationWithThreeDecks() throws Exception {
+        ShitheadGame game = newGame(3);
+        assertLayout(game);
+    }
+
     private static ShitheadGame newGame(int decks) {
         Deck deck = new Deck(decks);
         deck.setRandom(new Random(123));


### PR DESCRIPTION
### Motivation
- The existing layout test only exercised a single-deck deal and the UI assumed a 1:1 mapping from `Card` to `UICard`, which breaks when the game uses multiple decks because `Card` objects are singletons and can appear more than once in the game state.
- The intent is to ensure correct positioning and independent UI representation for duplicate cards from multi-deck games and to add coverage for 2-deck and 3-deck initial deals.

### Description
- Stop using a global `Map<Card, UICard>` and instead select a `UICard` from the current location/pool when laying out cards in `GameView` by updating `getUICard` to prefer `currentHandCardsAtLocation`, then `available`, then deck slots, and finally allocate a new `UICard` when needed (file: `client/src/main/java/net/yura/shithead/uicomponents/GameView.java`).
- Remove the global `cardToUICard` mapping and the global put into it, so the same `Card` singleton can be represented by distinct `UICard` instances when multiple decks are used (file: `client/src/main/java/net/yura/shithead/uicomponents/GameView.java`).
- Add two new tests to `GameViewTest` to verify initial card positions after animation for two-deck and three-deck games by calling `newGame(2)` and `newGame(3)` and reusing the existing layout assertions (file: `desktop/src/test/java/net/yura/shithead/uicomponents/GameViewTest.java`).

### Testing
- Ran `./gradlew :client:compileJava` which completed successfully.
- Attempted `./gradlew :client:compileJava :desktop:compileTestJava` and `./gradlew :desktop:test --tests net.yura.shithead.uicomponents.GameViewTest.testInitialCardPositionsAfterAnimation`, but those desktop test steps failed to resolve test dependencies (JUnit/Mockito/Awaitility) due to repository HTTP 403 responses, so desktop tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3801c173948331ae28ff1ece1508c7)